### PR TITLE
Add Custom Keystore

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,3 @@
 /build
+/debug/output-metadata.json
+/release/output-metadata.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,10 +20,23 @@ android {
         enabled = true
     }
 
+    signingConfigs {
+        release {
+            storeFile file('C:\\Program Files\\keystore\\defense_drill.jks')
+            storePassword System.getenv("DEFENSE_DRILL_STORE_PASSWORD")
+            keyAlias 'defenseDrillKey'
+            keyPassword System.getenv("DEFENSE_DRILL_KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
+        }
+        debug {
+            signingConfig signingConfigs.release
         }
     }
     compileOptions {


### PR DESCRIPTION
To allow compatible builds between devices, a personal store and key were created to allow the signatures to match from builds on different machines.