### PR TITLE
Feature: Known Drills

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,13 @@
         android:theme="@style/Theme.DefenseDrill"
         tools:targetApi="31">
         <activity
+            android:name=".ui.activities.UnlockDrillsActivity"
+            android:exported="false"
+            android:parentActivityName=".ui.activities.CustomizeDatabaseActivity"/>
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        <activity
             android:name=".ui.activities.SimulatedAttackSettingsActivity"
             android:exported="false"
             android:parentActivityName=".ui.activities.HomeActivity">

--- a/app/src/main/java/com/damienwesterman/defensedrill/data/local/DrillDao.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/data/local/DrillDao.java
@@ -110,6 +110,12 @@ import java.util.Optional;
     List<Drill> findAllDrillsByCategoryAndSubCategory(@NonNull List<Long> categoryIds, @NonNull List<Long> subCategoryIds);
 
     @Transaction
+    @Query("SELECT drill.* FROM " + DrillEntity.TABLE_NAME + " AS drill " +
+                    " WHERE drill.server_drill_id IN (:serverIds) ORDER BY drill.name")
+    @NonNull
+    List<Drill> findAllDrillsByServerId(@NonNull List<Long> serverIds);
+
+    @Transaction
     @Query("SELECT * FROM " + DrillEntity.TABLE_NAME + " WHERE id = :id")
     @NonNull
     Optional<Drill> findDrillById(long id);

--- a/app/src/main/java/com/damienwesterman/defensedrill/data/local/DrillEntity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/data/local/DrillEntity.java
@@ -61,7 +61,6 @@ import lombok.Setter;
     @Nullable
     @ColumnInfo(name = "server_drill_id")
     private Long serverDrillId;
-    // TODO: Future PR - Implement the features that make use of this, and use it during drill generation
     /** Represents whether the user knows the drill and if it should be used during drill generation */
     private boolean isKnownDrill;
 

--- a/app/src/main/java/com/damienwesterman/defensedrill/data/local/DrillRepository.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/data/local/DrillRepository.java
@@ -91,6 +91,17 @@ public class DrillRepository {
     }
 
     /**
+     * Returns a list of all Drills that have the supplied server IDs.
+     *
+     * @param serverIds List of Server IDs to retrieve.
+     * @return          List of Drill objects.
+     */
+    @NonNull
+    public synchronized List<Drill> getAllDrillsByServerId(@NonNull List<Long> serverIds) {
+        return this.drillDao.findAllDrillsByServerId(serverIds);
+    }
+
+    /**
      * Return a list of all Drills that belong to both the specified category and sub category.
      *
      * @param categoryId       ID of the specific category of drills.

--- a/app/src/main/java/com/damienwesterman/defensedrill/data/remote/dto/DrillDTO.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/data/remote/dto/DrillDTO.java
@@ -80,7 +80,7 @@ public class DrillDTO implements Serializable {
                 Drill.LOW_CONFIDENCE,
                 "",
                 id, // serverId
-                true,
+                false,
                 new ArrayList<>(),
                 new ArrayList<>()
         );

--- a/app/src/main/java/com/damienwesterman/defensedrill/domain/DownloadDatabaseUseCase.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/domain/DownloadDatabaseUseCase.java
@@ -106,29 +106,7 @@ public class DownloadDatabaseUseCase {
         categoryMap.clear();
         subCategoryMap.clear();
 
-        final long lastDrillUpdateTime = 1745070674000L;//sharedPrefs.getLastDrillUpdateTime(); TODO: PUT BACK
-drillRepo.deleteDrills(drillRepo.getAllDrills().toArray(new Drill[0])); // TODO: REMOVE - OBVIOUSLY
-            // TODO: This should update:
-                /*
-                Single Leg Takedown
-                Side Headlock Defense
-                Kimura: From Half Guard
-                Half Guard to Guard
-                Half Guard Sweep to Single Leg
-                Half Guard Sweep to Side Control
-                Half Guard Pass to Side Control
-                Half Guard
-                Guard Pass: Under
-                Guard Pass: Over
-                Double Leg Takedown
-                Double Arm Bar
-                Combo: Jab > Hook
-                Choke Escape: Front - Two Hands
-                Choke Escape: Bottom Guard - Hand Choke
-                Choke Escape: Front - Two Hands
-                Choke Escape: Bottom Guard - Hand Choke
-                Buck Trap and Roll
-                 */
+        final long lastDrillUpdateTime = sharedPrefs.getLastDrillUpdateTime();
         if (0 >= lastDrillUpdateTime) {
             // First download from the database, get all
             disposable = loadAllCategoriesFromServer()

--- a/app/src/main/java/com/damienwesterman/defensedrill/domain/DownloadDatabaseUseCase.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/domain/DownloadDatabaseUseCase.java
@@ -41,12 +41,12 @@ import com.damienwesterman.defensedrill.data.remote.dto.CategoryDTO;
 import com.damienwesterman.defensedrill.data.remote.dto.DrillDTO;
 import com.damienwesterman.defensedrill.data.remote.dto.SubCategoryDTO;
 import com.damienwesterman.defensedrill.manager.DefenseDrillNotificationManager;
-import com.damienwesterman.defensedrill.ui.utils.OperationCompleteCallback;
 
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -94,15 +94,41 @@ public class DownloadDatabaseUseCase {
     /**
      * Download and save all Drills, Categories, and SubCategories from the server.
      *
-     * @param callback Callback
+     * @param successCallback   Callback for successful operation. Takes in a list of newly added
+     *                          Drills. List may be empty.
+     * @param failureCallback   Callback for failure operation. Takes in a string containing the
+     *                          error message.
      */
-    public void download(OperationCompleteCallback callback) {
+    public void download(@NonNull Consumer<List<DrillDTO>> successCallback,
+                         @NonNull Consumer<String> failureCallback) {
         notificationManager.removeDatabaseUpdateAvailableNotification();
         databaseUpdated = false;
         categoryMap.clear();
         subCategoryMap.clear();
 
-        final long lastDrillUpdateTime = sharedPrefs.getLastDrillUpdateTime();
+        final long lastDrillUpdateTime = 1745070674000L;//sharedPrefs.getLastDrillUpdateTime(); TODO: PUT BACK
+drillRepo.deleteDrills(drillRepo.getAllDrills().toArray(new Drill[0])); // TODO: REMOVE - OBVIOUSLY
+            // TODO: This should update:
+                /*
+                Single Leg Takedown
+                Side Headlock Defense
+                Kimura: From Half Guard
+                Half Guard to Guard
+                Half Guard Sweep to Single Leg
+                Half Guard Sweep to Side Control
+                Half Guard Pass to Side Control
+                Half Guard
+                Guard Pass: Under
+                Guard Pass: Over
+                Double Leg Takedown
+                Double Arm Bar
+                Combo: Jab > Hook
+                Choke Escape: Front - Two Hands
+                Choke Escape: Bottom Guard - Hand Choke
+                Choke Escape: Front - Two Hands
+                Choke Escape: Bottom Guard - Hand Choke
+                Buck Trap and Roll
+                 */
         if (0 >= lastDrillUpdateTime) {
             // First download from the database, get all
             disposable = loadAllCategoriesFromServer()
@@ -110,15 +136,15 @@ public class DownloadDatabaseUseCase {
                     .flatMap(response -> loadAllDrillsFromServer())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
-                            response -> {
+                            newDrills -> {
                                 if (databaseUpdated) {
                                     sharedPrefs.setLastDrillUpdateTime(System.currentTimeMillis());
                                 }
-                                callback.onSuccess();
+                                successCallback.accept(newDrills);
                                 disposable = null;
                             },
                             throwable -> {
-                                callback.onFailure(extractErrorMessage(throwable));
+                                failureCallback.accept(extractErrorMessage(throwable));
                                 disposable = null;
                             }
                     );
@@ -129,15 +155,15 @@ public class DownloadDatabaseUseCase {
                     .flatMap(response -> updateDrillsFromServer(lastDrillUpdateTime))
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
-                            response -> {
+                            newDrills -> {
                                 if (databaseUpdated) {
                                     sharedPrefs.setLastDrillUpdateTime(System.currentTimeMillis());
                                 }
-                                callback.onSuccess();
+                                successCallback.accept(newDrills);
                                 disposable = null;
                             },
                             throwable -> {
-                                callback.onFailure(extractErrorMessage(throwable));
+                                failureCallback.accept(extractErrorMessage(throwable));
                                 disposable = null;
                             }
                     );
@@ -167,19 +193,18 @@ public class DownloadDatabaseUseCase {
      *
      * @return Observable for a List of DrillDTO objects.
      */
-    private Observable<Response<List<DrillDTO>>> loadAllDrillsFromServer() {
+    private Observable<List<DrillDTO>> loadAllDrillsFromServer() {
         return apiRepo.getAllDrills()
             .subscribeOn(Schedulers.io())
             .observeOn(Schedulers.io())
-            .doOnNext(
+            .map(
                 response -> {
                     switch (response.code()) {
                         case HttpsURLConnection.HTTP_OK:
-                            saveDrillsToDatabase(response.body(), false);
-                            break;
+                            return saveDrillsToDatabase(response.body(), false);
                         case HttpsURLConnection.HTTP_NO_CONTENT:
                             // Not an error, but nothing more to do here
-                            break;
+                            return List.of();
                         default:
                             // Failure
                             throw new HttpException(response);
@@ -247,19 +272,18 @@ public class DownloadDatabaseUseCase {
      * @param timestamp Timestamp of millis since epoch in UTC
      * @return Observable for a List of DrillDTO objects
      */
-    private Observable<Response<List<DrillDTO>>> updateDrillsFromServer(long timestamp) {
+    private Observable<List<DrillDTO>> updateDrillsFromServer(long timestamp) {
         return apiRepo.getAllDrillsUpdatedAfterTimestamp(timestamp)
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io())
-                .doOnNext(
+                .map(
                         response -> {
                             switch (response.code()) {
                                 case HttpsURLConnection.HTTP_OK:
-                                    saveDrillsToDatabase(response.body(), true);
-                                    break;
+                                    return saveDrillsToDatabase(response.body(), true);
                                 case HttpsURLConnection.HTTP_NO_CONTENT:
                                     // Not an error, but nothing more to do here
-                                    break;
+                                    return List.of();
                                 default:
                                     // Failure
                                     throw new HttpException(response);
@@ -331,8 +355,9 @@ public class DownloadDatabaseUseCase {
      *
      * @param drills List of drills to save
      * @param isUpdate true if this is an update operation, false if it is an insert operation
+     * @return List of Drills that are new to the database
      */
-    private void saveDrillsToDatabase(List<DrillDTO> drills, boolean isUpdate) {
+    private List<DrillDTO> saveDrillsToDatabase(List<DrillDTO> drills, boolean isUpdate) {
         if (null == drills) {
             // Shouldn't really happen
             throw new NullPointerException("Drill response.body() was NULL");
@@ -347,9 +372,9 @@ public class DownloadDatabaseUseCase {
         List<Drill> drillsToUpdate = new ArrayList<>();
 
         /*
-        We want to filter this list so that certain categories that may already
+        We want to filter this list so that certain drills that may already
         be in the database are not persisted again, causing issue. We are filtering
-        in place as the list ends in this method and is not used again.
+        in place as the list returned signals the newly added drills.
          */
         drills.removeIf(drill -> {
             if (drillServerIdMap.containsKey(drill.getId())) {
@@ -400,6 +425,8 @@ public class DownloadDatabaseUseCase {
                     drillsToUpdate.toArray(new Drill[0]));
             databaseUpdated = true;
         }
+
+        return drills;
     }
 
     /**

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
@@ -21,6 +21,11 @@ import com.damienwesterman.defensedrill.utils.Constants;
  * INTENTS: None expected.
  */
 public class CustomizeDatabaseActivity extends AppCompatActivity {
+    // TODO: Add an "unlock drills" activity
+        // TODO: This should basically be a list of cards as before, however we want to gray out anything that is "not known"
+        // TODO: On click should set in DB known or not known as well as change the card to "activate/deactivated" as denoted by gray or green
+        // TODO: There should be two buttons at the top: "showing/hiding learned drills" and "showing/hiding unknown drills"
+
     private LinearLayout rootView;
 
     // =============================================================================================

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
@@ -79,6 +79,8 @@ public class CustomizeDatabaseActivity extends AppCompatActivity {
         if (R.id.viewDrillsCard == cardId) {
             Intent intent = new Intent(this, ViewDrillsActivity.class);
             startActivity(intent);
+        } else if (R.id.unlockDrillsCard == cardId) {
+            UnlockDrillsActivity.startActivity(this);
         } else if (R.id.viewCategoriesCard == cardId) {
             Intent intent = new Intent(this, ViewAbstractCategoriesActivity.class);
             intent.putExtra(Constants.INTENT_EXTRA_VIEW_CATEGORIES, "");

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
@@ -21,11 +21,6 @@ import com.damienwesterman.defensedrill.utils.Constants;
  * INTENTS: None expected.
  */
 public class CustomizeDatabaseActivity extends AppCompatActivity {
-    // TODO: Add an "unlock drills" activity
-        // TODO: This should basically be a list of cards as before, however we want to gray out anything that is "not known"
-        // TODO: On click should set in DB known or not known as well as change the card to "activate/deactivated" as denoted by gray or green
-        // TODO: There should be two buttons at the top: "showing/hiding learned drills" and "showing/hiding unknown drills"
-
     private LinearLayout rootView;
 
     // =============================================================================================

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/DrillInfoActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/DrillInfoActivity.java
@@ -129,7 +129,6 @@ public class DrillInfoActivity extends AppCompatActivity {
     // =============================================================================================
     // Activity Creation Methods
     // =============================================================================================
-
     /**
      * Start DrillInfoActivity using a selected category and subcategory.
      *

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
@@ -1,0 +1,195 @@
+/****************************\
+ *      ________________      *
+ *     /  _             \     *
+ *     \   \ |\   _  \  /     *
+ *      \  / | \ / \  \/      *
+ *      /  \ | / | /  /\      *
+ *     /  _/ |/  \__ /  \     *
+ *     \________________/     *
+ *                            *
+ \****************************/
+/*
+ * Copyright 2025 Damien Westerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.damienwesterman.defensedrill.ui.activities;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewTreeObserver;
+import android.widget.Button;
+import android.widget.ProgressBar;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.damienwesterman.defensedrill.R;
+import com.damienwesterman.defensedrill.data.local.Drill;
+import com.damienwesterman.defensedrill.ui.adapters.UnlockDrillAdapter;
+import com.damienwesterman.defensedrill.ui.view_models.UnlockDrillsViewModel;
+
+import java.util.List;
+
+import dagger.hilt.android.AndroidEntryPoint;
+
+/**
+ * Activity to mark drills as known or unknown.
+ */
+@AndroidEntryPoint
+public class UnlockDrillsActivity extends AppCompatActivity {
+    private UnlockDrillsViewModel viewModel;
+
+    private View rootView;
+    private Button toggleKnownDrillsButton;
+    private Button toggleUnknownDrillsButton;
+    private ProgressBar progressBar;
+    private RecyclerView recyclerView;
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start UnlockDrillsActivity.
+     *
+     * @param context       Context.
+     */
+    public static void startActivity(Context context) {
+        Intent intent = new Intent(context, UnlockDrillsActivity.class);
+        context.startActivity(intent);
+    }
+
+    // =============================================================================================
+    // Activity Methods
+    // =============================================================================================
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_unlock_drills);
+
+        // Modify Toolbar
+        Toolbar appToolbar = findViewById(R.id.appToolbar);
+        appToolbar.setTitle("Unlock Drills");
+        setSupportActionBar(appToolbar);
+        if (null != getSupportActionBar()) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+        viewModel = new ViewModelProvider(this).get(UnlockDrillsViewModel.class);
+
+        rootView = findViewById(R.id.activityUnlockDrills);
+        toggleKnownDrillsButton = findViewById(R.id.toggleKnownDrillsButton);
+        toggleUnknownDrillsButton = findViewById(R.id.toggleUnknownDrillsButton);
+        progressBar = findViewById(R.id.unlockDrillsProgressBar);
+        recyclerView = findViewById(R.id.unlockDrillsRecyclerView);
+
+        viewModel.getDisplayedDrills().observe(this, this::setUpRecyclerView);
+        viewModel.populateDrills();
+    }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        // TODO: setLoading() and viewModel stuff - make sure to maintain the sorted order or whatever (and the button text)
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (R.id.homeButton == item.getItemId()) {
+            Intent intent = new Intent(this, HomeActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish();
+        return true;
+    }
+
+
+    // =============================================================================================
+    // OnClickListener Methods
+    // =============================================================================================
+    public void toggleKnownDrills(View view) {
+        // TODO: Set loading?
+        if (viewModel.isShowKnownDrills()) {
+            toggleKnownDrillsButton.setText(R.string.hiding_known_drills);
+            viewModel.setShowKnownDrills(false);
+        } else {
+            toggleKnownDrillsButton.setText(R.string.showing_known_drills);
+            viewModel.setShowKnownDrills(true);
+        }
+    }
+
+    public void toggleUnknownDrills(View view) {
+        // TODO: Set loading?
+        if (viewModel.isShowUnknownDrills()) {
+            toggleUnknownDrillsButton.setText(R.string.hiding_unknown_drills);
+            viewModel.setShowUnknownDrills(false);
+        } else {
+            toggleUnknownDrillsButton.setText(R.string.showing_unknown_drills);
+            viewModel.setShowUnknownDrills(true);
+        }
+    }
+
+    // =============================================================================================
+    // Private Helper Methods
+    // =============================================================================================
+    /**
+     * Callback method for when the drills list has been loaded from the database. Sets the UI and
+     * attaches checked listener.
+     *
+     * @param displayedDrills   List of Drill objects.
+     */
+    private void setUpRecyclerView(List<Drill> displayedDrills) {
+        recyclerView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                // Once all the items are rendered: remove this listener, hide progress bar
+                recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                // TODO: Change to set loading
+                progressBar.setVisibility(View.GONE);
+            }
+        });
+
+        recyclerView.setLayoutManager(new LinearLayoutManager((this)));
+        recyclerView.setAdapter(new UnlockDrillAdapter(displayedDrills,
+            // Checked Changed Listener
+            (drill, isChecked) -> {
+//                viewModel.setDrillKnown(drill, isChecked); TODO: START HERE - implement properly, may need a set or something in the viewModel
+            }));
+        recyclerView.addItemDecoration(
+                new DividerItemDecoration(this, DividerItemDecoration.VERTICAL));
+    }
+}

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
@@ -60,7 +60,6 @@ import dagger.hilt.android.AndroidEntryPoint;
 public class UnlockDrillsActivity extends AppCompatActivity {
     private UnlockDrillsViewModel viewModel;
 
-    private View rootView;
     private Button toggleKnownDrillsButton;
     private Button toggleUnknownDrillsButton;
     private ProgressBar progressBar;
@@ -97,7 +96,6 @@ public class UnlockDrillsActivity extends AppCompatActivity {
 
         viewModel = new ViewModelProvider(this).get(UnlockDrillsViewModel.class);
 
-        rootView = findViewById(R.id.activityUnlockDrills);
         toggleKnownDrillsButton = findViewById(R.id.toggleKnownDrillsButton);
         toggleUnknownDrillsButton = findViewById(R.id.toggleUnknownDrillsButton);
         progressBar = findViewById(R.id.unlockDrillsProgressBar);
@@ -110,7 +108,7 @@ public class UnlockDrillsActivity extends AppCompatActivity {
     @Override
     protected void onRestart() {
         super.onRestart();
-        // TODO: setLoading() and viewModel stuff - make sure to maintain the sorted order or whatever (and the button text)
+        viewModel.displayFilteredList();
     }
 
     @Override
@@ -142,7 +140,6 @@ public class UnlockDrillsActivity extends AppCompatActivity {
     // OnClickListener Methods
     // =============================================================================================
     public void toggleKnownDrills(View view) {
-        // TODO: Set loading?
         if (viewModel.isShowKnownDrills()) {
             toggleKnownDrillsButton.setText(R.string.hiding_known_drills);
             viewModel.setShowKnownDrills(false);
@@ -153,7 +150,6 @@ public class UnlockDrillsActivity extends AppCompatActivity {
     }
 
     public void toggleUnknownDrills(View view) {
-        // TODO: Set loading?
         if (viewModel.isShowUnknownDrills()) {
             toggleUnknownDrillsButton.setText(R.string.hiding_unknown_drills);
             viewModel.setShowUnknownDrills(false);
@@ -178,17 +174,12 @@ public class UnlockDrillsActivity extends AppCompatActivity {
             public void onGlobalLayout() {
                 // Once all the items are rendered: remove this listener, hide progress bar
                 recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                // TODO: Change to set loading
                 progressBar.setVisibility(View.GONE);
             }
         });
 
         recyclerView.setLayoutManager(new LinearLayoutManager((this)));
-        recyclerView.setAdapter(new UnlockDrillAdapter(displayedDrills,
-            // Checked Changed Listener
-            (drill, isChecked) -> {
-//                viewModel.setDrillKnown(drill, isChecked); TODO: START HERE - implement properly, may need a set or something in the viewModel
-            }));
+        recyclerView.setAdapter(new UnlockDrillAdapter(displayedDrills, viewModel::setDrillKnown));
         recyclerView.addItemDecoration(
                 new DividerItemDecoration(this, DividerItemDecoration.VERTICAL));
     }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
@@ -163,8 +163,8 @@ public class UnlockDrillsActivity extends AppCompatActivity {
     // Private Helper Methods
     // =============================================================================================
     /**
-     * Callback method for when the drills list has been loaded from the database. Sets the UI and
-     * attaches checked listener.
+     * Callback method for when the drills list has been loaded from the database or updated via
+     * filter. Sets the UI and attaches checked listener.
      *
      * @param displayedDrills   List of Drill objects.
      */

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewAbstractCategoriesActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewAbstractCategoriesActivity.java
@@ -85,7 +85,6 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
 
     private View rootView;
     private TextView title;
-    private TextView instructions;
     private Button createButton;
     private ProgressBar progressBar;
     private RecyclerView recyclerView;
@@ -126,7 +125,6 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
 
         rootView = findViewById(R.id.activityViewAbstractCategories);
         title = findViewById(R.id.allAbstractCategoriesText);
-        instructions = findViewById(R.id.allAbstractCategoriesInstruction);
         createButton = findViewById(R.id.createAbstractCategoryButton);
         progressBar = findViewById(R.id.allAbstractCategoriesProgressBar);
         recyclerView = findViewById(R.id.allAbstractCategoriesRecyclerView);
@@ -387,11 +385,9 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
     private void setScreenTextByMode() {
         if (ActivityMode.MODE_CATEGORIES == activityMode) {
             title.setText(R.string.categories);
-            instructions.setText(R.string.all_categories_instructions);
             createButton.setText(R.string.create_new_category);
         } else {
             title.setText(R.string.sub_categories);
-            instructions.setText(R.string.all_sub_categories_instructions);
             createButton.setText(R.string.create_new_sub_category);
         }
     }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
@@ -62,7 +62,7 @@ import dagger.hilt.android.AndroidEntryPoint;
  */
 @AndroidEntryPoint
 public class WebDrillOptionsActivity extends AppCompatActivity {
-    // TODO: after download, if there are new drills, make a popup (before saving)?
+    // TODO: after download, if there are new drills, make a popup?
         // TODO: this popup should show a scrollable list of all drills with a checkmark next to it
         // TODO: Can't close the popup
         // TODO: On save, mark (and save) those drills as known or unknown
@@ -188,21 +188,19 @@ public class WebDrillOptionsActivity extends AppCompatActivity {
 
         AlertDialog alert = builder.create();
 
-        viewModel.downloadDb(new OperationCompleteCallback() {
-            @Override
-            public void onSuccess() {
+        viewModel.downloadDb(
+            newDrills -> {
                 alert.dismiss();
                 UiUtils.displayDismissibleSnackbar(rootView, "Download Successful!");
-            }
-
-            @Override
-            public void onFailure(String error) {
+                // TODO: FIXME: START HERE - make a new popup that displays the list of drills in a check mark list to say if we know this one or not
+            },
+            error -> {
                 loadingText.setVisibility(View.GONE);
                 progressBar.setVisibility(View.GONE);
                 errorMessage.setText(error);
                 errorMessage.setVisibility(View.VISIBLE);
             }
-        });
+        );
 
         alert.show();
     }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -33,6 +34,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -43,12 +45,17 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.damienwesterman.defensedrill.R;
+import com.damienwesterman.defensedrill.data.local.Drill;
 import com.damienwesterman.defensedrill.data.local.SharedPrefs;
 import com.damienwesterman.defensedrill.domain.CheckPhoneInternetConnection;
 import com.damienwesterman.defensedrill.ui.utils.CommonPopups;
 import com.damienwesterman.defensedrill.ui.utils.OperationCompleteCallback;
 import com.damienwesterman.defensedrill.ui.utils.UiUtils;
 import com.damienwesterman.defensedrill.ui.view_models.WebDrillApiViewModel;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -191,8 +198,7 @@ public class WebDrillOptionsActivity extends AppCompatActivity {
         viewModel.downloadDb(
             newDrills -> {
                 alert.dismiss();
-                UiUtils.displayDismissibleSnackbar(rootView, "Download Successful!");
-                // TODO: FIXME: START HERE - make a new popup that displays the list of drills in a check mark list to say if we know this one or not
+                selectKnownDrillsPopup(newDrills);
             },
             error -> {
                 loadingText.setVisibility(View.GONE);
@@ -201,6 +207,77 @@ public class WebDrillOptionsActivity extends AppCompatActivity {
                 errorMessage.setVisibility(View.VISIBLE);
             }
         );
+
+        alert.show();
+    }
+
+    private void selectKnownDrillsPopup(@NonNull List<Drill> newDrills) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+        // The following two should line up completely in index positions, along with newDrills
+        final String[] drillNames = newDrills.stream()
+            .map(Drill::getName)
+            .toArray(String[]::new);
+        // They all start false
+        final boolean[] checkedKnownDrills = new boolean[drillNames.length];
+
+        builder.setTitle("New Drills! Select the ones you know:");
+        builder.setIcon(R.drawable.save_icon);
+        builder.setMultiChoiceItems(drillNames, checkedKnownDrills,
+                ((dialogInterface, position, isChecked) -> checkedKnownDrills[position] = isChecked));
+        builder.setCancelable(false);
+        builder.setPositiveButton("Save", null);
+        builder.setNegativeButton("Check All", null);
+        builder.setNeutralButton("Clear All", null);
+
+        AlertDialog alert = builder.create();
+        alert.setOnShowListener(dialogInterface -> {
+            alert.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(view -> {
+                // "Save"
+                List<Drill> knownDrills = new ArrayList<>(checkedKnownDrills.length);
+                for (int i = 0; i < checkedKnownDrills.length; i++) {
+                    if (checkedKnownDrills[i]) {
+                        knownDrills.add(newDrills.get(i));
+                    }
+                }
+
+                viewModel.markDrillsAsKnown(knownDrills, new OperationCompleteCallback() {
+                    @Override
+                    public void onSuccess() {
+                        alert.dismiss();
+                        UiUtils.displayDismissibleSnackbar(rootView, "Download Successful!");
+                    }
+
+                    @Override
+                    public void onFailure(String error) {
+                        alert.dismiss();
+                        UiUtils.displayDismissibleSnackbar(rootView, error);
+                    }
+                });
+            });
+
+            alert.getButton(DialogInterface.BUTTON_NEGATIVE).setOnClickListener(view -> {
+                // "Check All"
+                Arrays.fill(checkedKnownDrills, true);
+
+                ListView listView = alert.getListView();
+                for (int i = 0; i < listView.getCount(); i++) {
+                    listView.setItemChecked(i, true);
+                }
+                // Do not dismiss
+            });
+
+            alert.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(view -> {
+                // "Clear All"
+                Arrays.fill(checkedKnownDrills, false);
+
+                ListView listView = alert.getListView();
+                for (int i = 0; i < listView.getCount(); i++) {
+                    listView.setItemChecked(i, false);
+                }
+                // Do not dismiss
+            });
+        });
 
         alert.show();
     }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
@@ -69,10 +69,6 @@ import dagger.hilt.android.AndroidEntryPoint;
  */
 @AndroidEntryPoint
 public class WebDrillOptionsActivity extends AppCompatActivity {
-    // TODO: after download, if there are new drills, make a popup?
-        // TODO: this popup should show a scrollable list of all drills with a checkmark next to it
-        // TODO: Can't close the popup
-        // TODO: On save, mark (and save) those drills as known or unknown
     private LinearLayout rootView;
     @Inject
     SharedPrefs sharedPrefs;
@@ -212,6 +208,11 @@ public class WebDrillOptionsActivity extends AppCompatActivity {
     }
 
     private void selectKnownDrillsPopup(@NonNull List<Drill> newDrills) {
+        if (newDrills.isEmpty()) {
+            UiUtils.displayDismissibleSnackbar(rootView, "Download Successful!");
+            return;
+        }
+
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
 
         // The following two should line up completely in index positions, along with newDrills

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
@@ -62,6 +62,10 @@ import dagger.hilt.android.AndroidEntryPoint;
  */
 @AndroidEntryPoint
 public class WebDrillOptionsActivity extends AppCompatActivity {
+    // TODO: after download, if there are new drills, make a popup (before saving)?
+        // TODO: this popup should show a scrollable list of all drills with a checkmark next to it
+        // TODO: Can't close the popup
+        // TODO: On save, mark (and save) those drills as known or unknown
     private LinearLayout rootView;
     @Inject
     SharedPrefs sharedPrefs;

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/adapters/DrillAdapter.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/adapters/DrillAdapter.java
@@ -53,8 +53,8 @@ import java.util.Locale;
  */
 public class DrillAdapter extends RecyclerView.Adapter<CardViewHolder> {
     private final List<Drill> drills;
-    final CardClickListener clickListener;
-    final CardLongClickListener longClickListener;
+    private final CardClickListener clickListener;
+    private final CardLongClickListener longClickListener;
 
     public DrillAdapter(@NonNull List<Drill> drills, CardClickListener clickListener,
                         CardLongClickListener longClickListener) {

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/adapters/UnlockDrillAdapter.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/adapters/UnlockDrillAdapter.java
@@ -1,0 +1,90 @@
+/****************************\
+ *      ________________      *
+ *     /  _             \     *
+ *     \   \ |\   _  \  /     *
+ *      \  / | \ / \  \/      *
+ *      /  \ | / | /  /\      *
+ *     /  _/ |/  \__ /  \     *
+ *     \________________/     *
+ *                            *
+ \****************************/
+/*
+ * Copyright 2025 Damien Westerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.damienwesterman.defensedrill.ui.adapters;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.damienwesterman.defensedrill.R;
+import com.damienwesterman.defensedrill.data.local.Drill;
+import com.damienwesterman.defensedrill.ui.view_holders.CheckBoxListViewHolder;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * RecyclerView Adapter class for use with {@link Drill} objects.
+ * <br><br>
+ * Basically a checklist denoting if the Drill is known or not. Allows setting on the
+ * OnCheckedChangeListener.
+ */
+@RequiredArgsConstructor
+public class UnlockDrillAdapter extends RecyclerView.Adapter<CheckBoxListViewHolder> {
+    @NonNull
+    private final List<Drill> drills;
+    /**
+     * Callback for when the check box is checked. Accepts the related drill being checked and
+     * whether it is checked or not.
+     */
+    @Nullable
+    private final BiConsumer<Drill, Boolean> listener;
+
+    @NonNull
+    @Override
+    public CheckBoxListViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(
+                R.layout.layout_checked_item, parent, false
+        );
+
+        return new CheckBoxListViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull CheckBoxListViewHolder holder, int position) {
+        Drill drill = drills.get(position);
+
+        holder.setText(drill.getName());
+        holder.setChecked(drill.isKnownDrill());
+        holder.setOnCheckedListener((view, isChecked) -> {
+            if (null != listener) {
+                listener.accept(drill, isChecked);
+            }
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return drills.size();
+    }
+}

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/adapters/UnlockDrillAdapter.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/adapters/UnlockDrillAdapter.java
@@ -47,14 +47,14 @@ import lombok.RequiredArgsConstructor;
  * RecyclerView Adapter class for use with {@link Drill} objects.
  * <br><br>
  * Basically a checklist denoting if the Drill is known or not. Allows setting on the
- * OnCheckedChangeListener.
+ * OnCheckedChangeListener via BiConsumer.
  */
 @RequiredArgsConstructor
 public class UnlockDrillAdapter extends RecyclerView.Adapter<CheckBoxListViewHolder> {
     @NonNull
     private final List<Drill> drills;
     /**
-     * Callback for when the check box is checked. Accepts the related drill being checked and
+     * Callback for when the check box is checked. Passes in the drill being checked and boolean
      * whether it is checked or not.
      */
     @Nullable

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/view_holders/CheckBoxListViewHolder.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/view_holders/CheckBoxListViewHolder.java
@@ -1,0 +1,62 @@
+/****************************\
+ *      ________________      *
+ *     /  _             \     *
+ *     \   \ |\   _  \  /     *
+ *      \  / | \ / \  \/      *
+ *      /  \ | / | /  /\      *
+ *     /  _/ |/  \__ /  \     *
+ *     \________________/     *
+ *                            *
+ \****************************/
+/*
+ * Copyright 2025 Damien Westerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.damienwesterman.defensedrill.ui.view_holders;
+
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.damienwesterman.defensedrill.R;
+
+public class CheckBoxListViewHolder extends RecyclerView.ViewHolder {
+    private final CheckBox checkBox;
+    private final TextView text;
+
+    public CheckBoxListViewHolder(@NonNull View itemView) {
+        super(itemView);
+
+        checkBox = itemView.findViewById(R.id.checkBox);
+        text = itemView.findViewById(R.id.text);
+    }
+
+    public void setOnCheckedListener(@Nullable CompoundButton.OnCheckedChangeListener listener) {
+        checkBox.setOnCheckedChangeListener(listener);
+    }
+
+    public void setChecked(boolean checked) {
+        checkBox.setChecked(checked);
+    }
+
+    public void setText(@NonNull String string) {
+        text.setText(string);
+    }
+}

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/DrillListViewModel.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/DrillListViewModel.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import dagger.hilt.android.lifecycle.HiltViewModel;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * View model for {@link Drill} objects geared towards displaying a list of all drills, and allowing
@@ -58,10 +60,13 @@ public class DrillListViewModel extends AndroidViewModel {
     private final MutableLiveData<List<Drill>> drills;
     private List<CategoryEntity> allCategories;
     private List<SubCategoryEntity> allSubCategories;
+    @Setter
     private Set<Long> categoryFilterIds;
+    @Setter
     private Set<Long> subCategoryFilterIds;
     private final DrillRepository repo;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    @Getter
     private SortOrder sortOrder;
 
     public enum SortOrder {
@@ -180,10 +185,6 @@ public class DrillListViewModel extends AndroidViewModel {
         return categoryFilterIds;
     }
 
-    public void setCategoryFilterIds(Set<Long> categoryFilterIds) {
-        this.categoryFilterIds = categoryFilterIds;
-    }
-
     /**
      * Return a set of sub-category IDs currently being filtered.
      * <br><br>
@@ -198,10 +199,6 @@ public class DrillListViewModel extends AndroidViewModel {
         }
 
         return subCategoryFilterIds;
-    }
-
-    public void setSubCategoryFilterIds(Set<Long> subCategoryFilterIds) {
-        this.subCategoryFilterIds = subCategoryFilterIds;
     }
 
     /**
@@ -270,14 +267,5 @@ public class DrillListViewModel extends AndroidViewModel {
             drills.postValue(sortedDrills);
             sortOrder = newSortOrder;
         }
-    }
-
-    /**
-     * Return the current sort order.
-     *
-     * @return Current sort order.
-     */
-    public SortOrder getSortOrder() {
-        return sortOrder;
     }
 }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/DrillListViewModel.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/DrillListViewModel.java
@@ -102,7 +102,9 @@ public class DrillListViewModel extends AndroidViewModel {
      * Force re-load  the Drills from the database, even if they are already loaded.
      */
     public void rePopulateDrills() {
-        executor.execute(() -> drills.postValue(repo.getAllDrills()));
+        executor.execute(() -> drills.postValue(repo.getAllDrills().stream()
+            .filter(Drill::isKnownDrill)
+            .collect(Collectors.toList())));
     }
 
     /**
@@ -116,7 +118,9 @@ public class DrillListViewModel extends AndroidViewModel {
      * @param subCategoryIds    List of sub-category IDs to filter by.
      */
     public void filterDrills(@Nullable List<Long> categoryIds,@Nullable List<Long> subCategoryIds) {
-        executor.execute(() -> drills.postValue(repo.getAllDrills(categoryIds, subCategoryIds)));
+        executor.execute(() -> drills.postValue(repo.getAllDrills(categoryIds, subCategoryIds).stream()
+                .filter(Drill::isKnownDrill)
+                .collect(Collectors.toList())));
     }
 
     /**

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/UnlockDrillsViewModel.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/UnlockDrillsViewModel.java
@@ -1,0 +1,118 @@
+/****************************\
+ *      ________________      *
+ *     /  _             \     *
+ *     \   \ |\   _  \  /     *
+ *      \  / | \ / \  \/      *
+ *      /  \ | / | /  /\      *
+ *     /  _/ |/  \__ /  \     *
+ *     \________________/     *
+ *                            *
+ \****************************/
+/*
+ * Copyright 2025 Damien Westerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.damienwesterman.defensedrill.ui.view_models;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.MutableLiveData;
+
+import com.damienwesterman.defensedrill.data.local.Drill;
+import com.damienwesterman.defensedrill.data.local.DrillRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import dagger.hilt.android.lifecycle.HiltViewModel;
+import lombok.Getter;
+
+/**
+ * View model for {@link Drill} objects geared towards displaying a list of all drills, and allowing
+ * changing the value of {@link Drill#isKnownDrill()}.
+ */
+@HiltViewModel
+public class UnlockDrillsViewModel extends AndroidViewModel {
+    private final DrillRepository repo;
+
+    @Getter
+    private final MutableLiveData<List<Drill>> displayedDrills;
+    private List<Drill> allDrills;
+    @Getter
+    private boolean showKnownDrills;
+    @Getter
+    private boolean showUnknownDrills;
+
+    @Inject
+    public UnlockDrillsViewModel(@NonNull Application application, DrillRepository repo) {
+        super(application);
+
+        this.repo = repo;
+
+        displayedDrills = new MutableLiveData<>();
+        showKnownDrills = true;
+        showUnknownDrills = true;
+    }
+
+    public void populateDrills() {
+        if (null == allDrills) {
+            new Thread(() -> {
+                allDrills = repo.getAllDrills();
+                displayedDrills.postValue(allDrills);
+            }).start();
+        }
+    }
+
+    /**
+     * Set whether we should show known drills in the list. Re-loads the list.
+     *
+     * @param show  true if we should show known drills.
+     */
+    public void setShowKnownDrills(boolean show) {
+        this.showKnownDrills = show;
+        filterList();
+    }
+
+    /**
+     * Set whether we should show unknown drills in the list. Re-loads the list.
+     *
+     * @param show  true if we should show unknown drills.
+     */
+    public void setShowUnknownDrills(boolean show) {
+        this.showUnknownDrills = show;
+        filterList();
+    }
+
+    /**
+     * Filter the displayed drills based on the current filter settings.
+     */
+    public void filterList() {
+        displayedDrills.postValue(allDrills.stream()
+            .filter(drill -> {
+                if (!showKnownDrills && drill.isKnownDrill()) {
+                    return false;
+                } else if (!showUnknownDrills && !drill.isKnownDrill()) {
+                    return false;
+                } else {
+                    return true;
+                }
+            })
+            .collect(Collectors.toList()));
+    }
+}

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/WebDrillApiViewModel.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/WebDrillApiViewModel.java
@@ -73,8 +73,7 @@ public class WebDrillApiViewModel extends AndroidViewModel {
      */
     public void downloadDb(@NonNull Consumer<List<Drill>> successCallback,
                            @NonNull Consumer<String> failureCallback) {
-        // TODO: REMOVE TEST CODE
-        new Thread(() -> downloadDb.download(successCallback, failureCallback)).start();
+        downloadDb.download(successCallback, failureCallback);
     }
 
     /**

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/WebDrillApiViewModel.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/WebDrillApiViewModel.java
@@ -31,8 +31,12 @@ import android.app.Application;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
 
+import com.damienwesterman.defensedrill.data.remote.dto.DrillDTO;
 import com.damienwesterman.defensedrill.domain.DownloadDatabaseUseCase;
 import com.damienwesterman.defensedrill.ui.utils.OperationCompleteCallback;
+
+import java.util.List;
+import java.util.function.Consumer;
 
 import javax.inject.Inject;
 
@@ -56,10 +60,14 @@ public class WebDrillApiViewModel extends AndroidViewModel {
      * Begin the operation to download and save all Drills, Categories, and SubCategories from the
      * server.
      *
-     * @param callback Callback
+     * @param successCallback   Callback for successful operation. Takes in a list of newly added
+     *                          Drills. List may be empty.
+     * @param failureCallback   Callback for failure operation. Takes in a string containing the
+     *                          error message.
      */
-    public void downloadDb(OperationCompleteCallback callback) {
-        downloadDb.download(callback);
+    public void downloadDb(@NonNull Consumer<List<DrillDTO>> successCallback,
+                           @NonNull Consumer<String> failureCallback) {
+        downloadDb.download(successCallback, failureCallback);
     }
 
     /**

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/WebDrillApiViewModel.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/view_models/WebDrillApiViewModel.java
@@ -54,8 +54,8 @@ public class WebDrillApiViewModel extends AndroidViewModel {
 
     @Inject
     public WebDrillApiViewModel(@NonNull Application application,
-                                DownloadDatabaseUseCase downloadDb,
-                                DrillRepository drillRepo) {
+                                @NonNull DownloadDatabaseUseCase downloadDb,
+                                @NonNull DrillRepository drillRepo) {
         super(application);
 
         this.downloadDb = downloadDb;

--- a/app/src/main/java/com/damienwesterman/defensedrill/utils/DrillGenerator.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/utils/DrillGenerator.java
@@ -126,8 +126,9 @@ public class DrillGenerator {
      */
     private Map<Long, Drill> idDrillMapFromDrillList(List<Drill> drills) {
         return drills.stream()
-                .filter(Objects::nonNull)
-                .collect(Collectors.toMap(
+            .filter(Objects::nonNull)
+            .filter(Drill::isKnownDrill)
+            .collect(Collectors.toMap(
                 Drill::getId,
                 drill -> drill,
                 (existing, replacement) -> existing,

--- a/app/src/main/res/layout/activity_customize_database.xml
+++ b/app/src/main/res/layout/activity_customize_database.xml
@@ -39,6 +39,17 @@
             android:onClick="onCardClick" />
 
         <com.damienwesterman.defensedrill.ui.utils.TitleDescCard
+            android:id="@+id/unlockDrillsCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            app:cardCornerRadius="8dp"
+            app:title="@string/unlock_drills_title"
+            app:description="@string/unlock_drills_description"
+            android:onClick="onCardClick" />
+
+        <com.damienwesterman.defensedrill.ui.utils.TitleDescCard
             android:id="@+id/viewCategoriesCard"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_unlock_drills.xml
+++ b/app/src/main/res/layout/activity_unlock_drills.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.activities.UnlockDrillsActivity"
+    android:id="@+id/activityUnlockDrills" >
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/appToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimaryVariant"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/drills"
+        android:textAlignment="center"
+        android:textSize="36sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/toggleKnownDrillsButton"
+            android:onClick="toggleKnownDrills"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="12dp"
+            android:layout_weight="1"
+            android:text="@string/showing_known_drills"
+            tools:ignore="ButtonStyle" />
+
+        <Button
+            android:id="@+id/toggleUnknownDrillsButton"
+            android:onClick="toggleUnknownDrills"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_weight="1"
+            android:text="@string/showing_unknown_drills"
+            tools:ignore="ButtonStyle" />
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="8dp"
+        android:background="?attr/dividerColor"/>
+
+    <ProgressBar
+        android:id="@+id/unlockDrillsProgressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/unlockDrillsRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_view_abstract_categories.xml
+++ b/app/src/main/res/layout/activity_view_abstract_categories.xml
@@ -25,14 +25,6 @@
         android:textSize="36sp"
         android:textStyle="bold" />
 
-    <TextView
-        android:id="@+id/allAbstractCategoriesInstruction"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textAlignment="center"
-        android:textStyle="italic"
-        android:textSize="20sp" />
-
     <Button
         android:id="@+id/createAbstractCategoryButton"
         android:onClick="createAbstractCategory"

--- a/app/src/main/res/layout/activity_view_drills.xml
+++ b/app/src/main/res/layout/activity_view_drills.xml
@@ -26,15 +26,6 @@
         android:textSize="36sp"
         android:textStyle="bold" />
 
-    <TextView
-        android:id="@+id/allDrillsInstruction"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/all_drills_instruction"
-        android:textAlignment="center"
-        android:textStyle="italic"
-        android:textSize="20sp" />
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/layout_checked_item.xml
+++ b/app/src/main/res/layout/layout_checked_item.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="2dp">
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:textSize="16sp" />
+
+    <CheckBox
+        android:id="@+id/checkBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_alignParentEnd="true" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,12 @@ To get the most out of this exercise, try to figure out three different solution
 
 3. Preventative Solution: How could you have prevented this attack from happening? This may usually just boil down to not being there, allowing yourself an easy escape, or having been more vigilant."
     </string>
+    <string name="unlock_drills_title">Unlock Drills</string>
+    <string name="unlock_drills_description">Display a list of all saved Drills and mark which ones you know. Only known Drills will be shown and used during Drill generation.</string>
+    <string name="showing_known_drills">Showing Known Drills</string>
+    <string name="hiding_known_drills">Hiding Known Drills</string>
+    <string name="showing_unknown_drills">Showing Unknown Drills</string>
+    <string name="hiding_unknown_drills">Hiding Unknown Drills</string>
     <string-array name="daily_hours">
         <item>12:00 AM</item>
         <item>1:00 AM</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,6 @@
     <string name="filter_by_category">Filter By Category</string>
     <string name="filter_by_sub_category">Filter by sub-Category</string>
     <string name="reset_filters">Reset Filters</string>
-    <string name="all_drills_instruction">Click to view/edit a Drill, hold to delete</string>
     <string name="create_new_drill">Create New Drill</string>
     <string name="name_label">Name:</string>
     <string name="create_new_drill_title">Create New Drill</string>
@@ -50,7 +49,6 @@
     <string name="add_sub_categories">Add sub-Categories</string>
     <string name="save_drill">Save Drill</string>
     <string name="categories">Categories</string>
-    <string name="all_categories_instructions">Click to view/edit a Category, hold to delete</string>
     <string name="create_new_category">Create New Category</string>
     <string name="sub_categories">Sub-Categories</string>
     <string name="all_sub_categories_instructions">Click to view/edit a sub-Category, hold to delete</string>


### PR DESCRIPTION
Users should be able to decide which of the Drills they "know" and have actually learned. This will allow them to only focus on drills they have been taught and not have to wade through techniques they have not been taught but were downloaded from the server. The following requirements are necessary before merging:
- [x] When downloading drills form the server (first time or update), the user will be prompted with a list of new drills. They will have to select which of the new drills they know and which they don't. This should be reflected in the database.
- [x] There should be a new option in the Customize Database Activity that allows the user to change the "known" status of drills
- [x] Only "known" drills should be selected during drill generation