### PR TITLE
Refactoring Activity Start into static methods

### DIFF
--- a/app/src/main/java/com/damienwesterman/defensedrill/manager/DefenseDrillNotificationManager.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/manager/DefenseDrillNotificationManager.java
@@ -88,7 +88,7 @@ public class DefenseDrillNotificationManager {
             return;
         }
 
-        Intent intent = new Intent(context, WebDrillOptionsActivity.class);
+        Intent intent = WebDrillOptionsActivity.createIntentToStartActivity(context);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         PendingIntent pendingIntent = PendingIntent.getActivity(
                 context,

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CategorySelectActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CategorySelectActivity.java
@@ -91,9 +91,7 @@ public class CategorySelectActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CategorySelectActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CategorySelectActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -55,11 +56,33 @@ import dagger.hilt.android.AndroidEntryPoint;
  * Activity during Drill Generation to select a Category of drill, or random.
  * <br><br>
  * Then Launches {@link SubCategorySelectActivity} sending the selected Category.
- * <br><br>
- * INTENTS: None required.
  */
 @AndroidEntryPoint
 public class CategorySelectActivity extends AppCompatActivity {
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the CategorySelectActivity.
+     *
+     * @param context   Context.
+     */
+    public static void startActivity(@NonNull Context context) {
+        Intent intent = new Intent(context, CategorySelectActivity.class);
+        context.startActivity(intent);
+    }
+
+    /**
+     * Start the CategorySelectActivity. Clears the activity stack so CategorySelect is now the top.
+     *
+     * @param context   Context.
+     */
+    public static void startActivityClearTop(@NonNull Context context) {
+        Intent intent = new Intent(context, CategorySelectActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+    }
 
     // =============================================================================================
     // Activity Methods
@@ -108,9 +131,7 @@ public class CategorySelectActivity extends AppCompatActivity {
     // OnClickListener Methods
     // =============================================================================================
     public void randomCategoryClick(View view) {
-        Intent intent = new Intent(this, SubCategorySelectActivity.class);
-        intent.putExtra(Constants.INTENT_EXTRA_CATEGORY_CHOICE, Constants.USER_RANDOM_SELECTION);
-        startActivity(intent);
+        SubCategorySelectActivity.startActivity(this, Constants.USER_RANDOM_SELECTION);
     }
 
     // =============================================================================================
@@ -137,12 +158,10 @@ public class CategorySelectActivity extends AppCompatActivity {
         runOnUiThread(() -> {
             recyclerView.setLayoutManager(new LinearLayoutManager(this));
             recyclerView.setAdapter(new AbstractCategoryAdapter(categories,
-                    // Card click listener
-                    id -> {
-                Intent intent = new Intent(this, SubCategorySelectActivity.class);
-                intent.putExtra(Constants.INTENT_EXTRA_CATEGORY_CHOICE, id);
-                startActivity(intent);
-            }, null));
+                // Card Click Listener
+                id -> SubCategorySelectActivity.startActivity(this, id),
+                // Long Card Click Listener
+                null));
         });
     }
 }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CreateDrillActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CreateDrillActivity.java
@@ -126,9 +126,7 @@ public class CreateDrillActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CreateDrillActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CreateDrillActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -64,8 +65,6 @@ import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * Activity to create a new Drill.
- * <br><br>
- * INTENTS: None required.
  */
 @AndroidEntryPoint
 public class CreateDrillActivity extends AppCompatActivity {
@@ -78,6 +77,19 @@ public class CreateDrillActivity extends AppCompatActivity {
     private Button subCategoriesButton;
     private EditText enteredNotes;
     private Snackbar savingSnackbar;
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the CreateDrillActivity.
+     *
+     * @param context   Context.
+     */
+    public static void startActivity(@NonNull Context context) {
+        Intent intent = new Intent(context, CreateDrillActivity.class);
+        context.startActivity(intent);
+    }
 
     // =============================================================================================
     // Activity Methods

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
@@ -51,9 +51,7 @@ public class CustomizeDatabaseActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/CustomizeDatabaseActivity.java
@@ -1,5 +1,6 @@
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -13,15 +14,25 @@ import androidx.appcompat.widget.Toolbar;
 
 import com.damienwesterman.defensedrill.R;
 import com.damienwesterman.defensedrill.ui.utils.UiUtils;
-import com.damienwesterman.defensedrill.utils.Constants;
 
 /**
  * Screen to offer the user options for altering the local database via CRUD operations.
- * <br><br>
- * INTENTS: None expected.
  */
 public class CustomizeDatabaseActivity extends AppCompatActivity {
     private LinearLayout rootView;
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the CustomizeDatabaseActivity.
+     *
+     * @param context   Context.
+     */
+    public static void startActivity(@NonNull Context context) {
+        Intent intent = new Intent(context, CustomizeDatabaseActivity.class);
+        context.startActivity(intent);
+    }
 
     // =============================================================================================
     // Activity Methods
@@ -70,18 +81,15 @@ public class CustomizeDatabaseActivity extends AppCompatActivity {
     public void onCardClick(View view) {
         int cardId = view.getId();
         if (R.id.viewDrillsCard == cardId) {
-            Intent intent = new Intent(this, ViewDrillsActivity.class);
-            startActivity(intent);
+            ViewDrillsActivity.startActivity(this);
         } else if (R.id.unlockDrillsCard == cardId) {
             UnlockDrillsActivity.startActivity(this);
         } else if (R.id.viewCategoriesCard == cardId) {
-            Intent intent = new Intent(this, ViewAbstractCategoriesActivity.class);
-            intent.putExtra(Constants.INTENT_EXTRA_VIEW_CATEGORIES, "");
-            startActivity(intent);
+            ViewAbstractCategoriesActivity.startActivity(this,
+                    ViewAbstractCategoriesActivity.ActivityMode.MODE_CATEGORIES);
         } else if (R.id.viewSubCategoriesCard == cardId) {
-            Intent intent = new Intent(this, ViewAbstractCategoriesActivity.class);
-            intent.putExtra(Constants.INTENT_EXTRA_VIEW_SUB_CATEGORIES, "");
-            startActivity(intent);
+            ViewAbstractCategoriesActivity.startActivity(this,
+                    ViewAbstractCategoriesActivity.ActivityMode.MODE_SUB_CATEGORIES);
         } else {
             UiUtils.displayDismissibleSnackbar(rootView, "Unknown option");
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/DrillInfoActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/DrillInfoActivity.java
@@ -258,9 +258,7 @@ public class DrillInfoActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         } else if (ActivityState.SIMULATED_ATTACK_DRILL == activityState
@@ -611,9 +609,7 @@ public class DrillInfoActivity extends AppCompatActivity {
         builder.setMessage(message);
         builder.setCancelable(false);
         builder.setPositiveButton("Go Home", (dialog, position) -> {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
         });
         switch(activityState) {
             case REGENERATED_DRILL:

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/DrillInfoActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/DrillInfoActivity.java
@@ -136,7 +136,7 @@ public class DrillInfoActivity extends AppCompatActivity {
      * @param categoryId    Category ID.
      * @param subCategoryId SubCategory ID.
      */
-    public static void startActivity(Context context, long categoryId, long subCategoryId) {
+    public static void startActivity(@NonNull Context context, long categoryId, long subCategoryId) {
         Intent intent = new Intent(context, DrillInfoActivity.class);
         intent.putExtra(Constants.INTENT_EXTRA_CATEGORY_CHOICE, categoryId);
         intent.putExtra(Constants.INTENT_EXTRA_SUB_CATEGORY_CHOICE, subCategoryId);
@@ -149,7 +149,7 @@ public class DrillInfoActivity extends AppCompatActivity {
      * @param context   Context.
      * @param drillId   Drill ID.
      */
-    public static void startActivity(Context context, long drillId) {
+    public static void startActivity(@NonNull Context context, long drillId) {
         Intent intent = new Intent(context, DrillInfoActivity.class);
         intent.putExtra(Constants.INTENT_EXTRA_DRILL_ID, drillId);
         context.startActivity(intent);
@@ -164,7 +164,8 @@ public class DrillInfoActivity extends AppCompatActivity {
      * @param drillId   Drill ID.
      * @return          Intent that can then start the DrillInfoActivity.
      */
-    public static Intent createIntentToStartActivityFromSimulatedAttack(Context context, long drillId) {
+    public static Intent createIntentToStartActivityFromSimulatedAttack(@NonNull Context context,
+                                                                        long drillId) {
         Intent intent = new Intent(context, DrillInfoActivity.class);
         intent.putExtra(Constants.INTENT_EXTRA_DRILL_ID, drillId);
         intent.putExtra(Constants.INTENT_EXTRA_SIMULATED_ATTACK, "");
@@ -581,9 +582,7 @@ public class DrillInfoActivity extends AppCompatActivity {
                     break;
                 case 1:
                     // New Category
-                    Intent intent = new Intent(this, CategorySelectActivity.class);
-                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-                    startActivity(intent);
+                    CategorySelectActivity.startActivityClearTop(this);
                     break;
             }
         });
@@ -608,24 +607,20 @@ public class DrillInfoActivity extends AppCompatActivity {
         builder.setIcon(R.drawable.warning_icon);
         builder.setMessage(message);
         builder.setCancelable(false);
-        builder.setPositiveButton("Go Home", (dialog, position) -> {
-            HomeActivity.startActivity(this);
-        });
+        builder.setPositiveButton("Go Home", (dialog, position) ->
+                HomeActivity.startActivity(this));
         switch(activityState) {
             case REGENERATED_DRILL:
-                // Fallthrough intentional
                 builder.setNeutralButton("Reset skipped Drills", (dialog, position) -> {
                     setUiLoading(true);
                     viewModel.resetSkippedDrills();
                     activityState = ActivityState.GENERATED_DRILL;
                     viewModel.regenerateDrill();
                 });
+                // Fallthrough intentional
             case GENERATED_DRILL:
-                builder.setNegativeButton("Select different Category", (dialog, position) -> {
-                    Intent intent = new Intent(this, CategorySelectActivity.class);
-                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-                    startActivity(intent);
-                });
+                builder.setNegativeButton("Select different Category", (dialog, position) ->
+                        CategorySelectActivity.startActivityClearTop(this));
                 break;
             case DISPLAYING_DRILL:
                 // Fallthrough intentional
@@ -919,10 +914,7 @@ public class DrillInfoActivity extends AppCompatActivity {
             return;
         }
 
-        Intent intent = new Intent(this, InstructionsActivity.class);
-        intent.putExtra(Constants.INTENT_EXTRA_DRILL_DTO, drillDTO);
-        intent.putExtra(Constants.INTENT_EXTRA_INSTRUCTION_INDEX, instructionsIndex);
-        startActivity(intent);
+        InstructionsActivity.startActivity(this, drillDTO, instructionsIndex);
     }
 
     /**

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/HomeActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/HomeActivity.java
@@ -30,7 +30,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -43,7 +42,6 @@ import com.damienwesterman.defensedrill.domain.CheckPhoneInternetConnection;
 import com.damienwesterman.defensedrill.manager.SimulatedAttackManager;
 import com.damienwesterman.defensedrill.service.CheckServerUpdateService;
 import com.damienwesterman.defensedrill.ui.utils.UiUtils;
-import com.damienwesterman.defensedrill.utils.Constants;
 
 import javax.inject.Inject;
 
@@ -52,8 +50,6 @@ import dagger.hilt.android.AndroidEntryPoint;
 /**
  * Home screen activity and entry point for the application. Displays the different general
  * functionalities of the app. CRUD operations in the database, Drill generation, and feedback.
- * <br><br>
- * INTENTS: None expected.
  */
 @AndroidEntryPoint
 public class HomeActivity extends AppCompatActivity {
@@ -79,7 +75,7 @@ public class HomeActivity extends AppCompatActivity {
      *
      * @param context   Context.
      */
-    public static void startActivity(Context context) {
+    public static void startActivity(@NonNull Context context) {
         Intent intent = new Intent(context, HomeActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
@@ -114,22 +110,19 @@ public class HomeActivity extends AppCompatActivity {
     // =============================================================================================
     // OnClickListener Methods
     // =============================================================================================
-    public void onCardClick(View view) {
+    public void onCardClick(@NonNull View view) {
         int cardId = view.getId();
         if (R.id.generateDrillCard == cardId) {
-            Intent intent = new Intent(this, CategorySelectActivity.class);
-            startActivity(intent);
+            CategorySelectActivity.startActivityClearTop(this);
         } else if (R.id.customizeDatabaseCard == cardId) {
-            Intent intent = new Intent(this, CustomizeDatabaseActivity.class);
-            startActivity(intent);
+            CustomizeDatabaseActivity.startActivity(this);
         } else if (R.id.simulatedAttackSettings == cardId) {
             SimulatedAttackSettingsActivity.startActivity(this);
         } else if (R.id.webDrillOptionsCard == cardId) {
             if (!internetConnection.isNetworkConnected()) {
                 UiUtils.displayDismissibleSnackbar(rootView, "No internet connection.");
             } else {
-                Intent intent = new Intent(this, WebDrillOptionsActivity.class);
-                startActivity(intent);
+                WebDrillOptionsActivity.startActivity(this);
             }
         } else if (R.id.feedbackCard == cardId) {
             UiUtils.displayDismissibleSnackbar(rootView, "Feedback unimplemented");

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/HomeActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/HomeActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -42,6 +43,7 @@ import com.damienwesterman.defensedrill.domain.CheckPhoneInternetConnection;
 import com.damienwesterman.defensedrill.manager.SimulatedAttackManager;
 import com.damienwesterman.defensedrill.service.CheckServerUpdateService;
 import com.damienwesterman.defensedrill.ui.utils.UiUtils;
+import com.damienwesterman.defensedrill.utils.Constants;
 
 import javax.inject.Inject;
 
@@ -70,6 +72,20 @@ public class HomeActivity extends AppCompatActivity {
     SimulatedAttackManager simulatedAttackManager;
 
     // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the HomeActivity. Clears the activity stack so home is now the top.
+     *
+     * @param context   Context.
+     */
+    public static void startActivity(Context context) {
+        Intent intent = new Intent(context, HomeActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+    }
+
+    // =============================================================================================
     // Activity Methods
     // =============================================================================================
     @Override
@@ -93,18 +109,6 @@ public class HomeActivity extends AppCompatActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu, menu);
         return super.onCreateOptionsMenu(menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
-            finish();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
     }
 
     // =============================================================================================

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/InstructionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/InstructionsActivity.java
@@ -155,9 +155,7 @@ public class InstructionsActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/InstructionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/InstructionsActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -54,17 +55,31 @@ import java.util.List;
 
 /**
  * Displays the a list of Instructions for a given drill Drill.
- * <br><br>
- * INTENTS: Expects to receive BOTH of the following-
- * <ul>
- *    <li> A {@link Constants#INTENT_EXTRA_DRILL_DTO} intent.</li>
- *    <li> A {@link Constants#INTENT_EXTRA_INSTRUCTION_INDEX} intent.</li>
- * </ul>
  */
 public class InstructionsActivity extends AppCompatActivity {
     private String videoId;
 
     private LinearLayout rootView;
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the InstructionsActivity using a Drill and position in the instructions array.
+     *
+     * @param context               Context.
+     * @param drill                 Drill.
+     * @param instructionsIndex     Index position of the desired instructions in the Drill's
+     *                              instructions array.
+     */
+    public static void startActivity(@NonNull Context context,
+                                     @NonNull DrillDTO drill,
+                                     int instructionsIndex) {
+        Intent intent = new Intent(context, InstructionsActivity.class);
+        intent.putExtra(Constants.INTENT_EXTRA_DRILL_DTO, drill);
+        intent.putExtra(Constants.INTENT_EXTRA_INSTRUCTION_INDEX, instructionsIndex);
+        context.startActivity(intent);
+    }
 
     // =============================================================================================
     // Activity Methods

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SimulatedAttackSettingsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SimulatedAttackSettingsActivity.java
@@ -108,7 +108,7 @@ public class SimulatedAttackSettingsActivity extends AppCompatActivity {
     // =============================================================================================
     // Activity Creation Methods
     // =============================================================================================
-    public static void startActivity(Context context) {
+    public static void startActivity(@NonNull Context context) {
         Intent intent = new Intent(context, SimulatedAttackSettingsActivity.class);
         context.startActivity(intent);
     }
@@ -441,8 +441,7 @@ public class SimulatedAttackSettingsActivity extends AppCompatActivity {
             switch (position) {
                 case 0:
                     // Download Drills from Database
-                    Intent webDrillsIntent = new Intent(this, WebDrillOptionsActivity.class);
-                    startActivity(webDrillsIntent);
+                    WebDrillOptionsActivity.startActivity(this);
                     break;
                 case 1:
                     // Create Self Defense Category
@@ -452,9 +451,7 @@ public class SimulatedAttackSettingsActivity extends AppCompatActivity {
                             Snackbar snackbar = Snackbar.make(rootView,
                                     "Category Created!", Snackbar.LENGTH_INDEFINITE);
                             snackbar.setAction("Create Drills", (callingView) -> {
-                                Intent createDrillsIntent =
-                                        new Intent(context, CreateDrillActivity.class);
-                                startActivity(createDrillsIntent);
+                                CreateDrillActivity.startActivity(context);
                                 snackbar.dismiss();
                             });
                             snackbar.show();

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SimulatedAttackSettingsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SimulatedAttackSettingsActivity.java
@@ -175,9 +175,7 @@ public class SimulatedAttackSettingsActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SubCategorySelectActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SubCategorySelectActivity.java
@@ -119,9 +119,7 @@ public class SubCategorySelectActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SubCategorySelectActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/SubCategorySelectActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -59,8 +60,6 @@ import dagger.hilt.android.AndroidEntryPoint;
  * <br><br>
  * Proceeds {@link CategorySelectActivity}, then Launches {@link DrillInfoActivity} sending the
  * selected Category and SubCategory.
- * <br><br>
- * INTENTS: Expects to receive a {@link Constants#INTENT_EXTRA_CATEGORY_CHOICE} intent.
  */
 @AndroidEntryPoint
 public class SubCategorySelectActivity extends AppCompatActivity {
@@ -69,6 +68,21 @@ public class SubCategorySelectActivity extends AppCompatActivity {
     SubCategoryViewModel subCategoryViewModel;
     CategoryViewModel categoryViewModel;
     long selectedCategoryId;
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the SubCategorySelectActivity.
+     *
+     * @param context           Context.
+     * @param categoryChoice    Category ID the user chose, or {@link Constants#USER_RANDOM_SELECTION}.
+     */
+    public static void startActivity(@NonNull Context context, long categoryChoice) {
+        Intent intent = new Intent(context, SubCategorySelectActivity.class);
+        intent.putExtra(Constants.INTENT_EXTRA_CATEGORY_CHOICE, categoryChoice);
+        context.startActivity(intent);
+    }
 
     // =============================================================================================
     // Activity Methods

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
@@ -120,9 +120,7 @@ public class UnlockDrillsActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/UnlockDrillsActivity.java
@@ -73,7 +73,7 @@ public class UnlockDrillsActivity extends AppCompatActivity {
      *
      * @param context       Context.
      */
-    public static void startActivity(Context context) {
+    public static void startActivity(@NonNull Context context) {
         Intent intent = new Intent(context, UnlockDrillsActivity.class);
         context.startActivity(intent);
     }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewAbstractCategoriesActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewAbstractCategoriesActivity.java
@@ -26,9 +26,11 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -70,12 +72,10 @@ import dagger.hilt.android.AndroidEntryPoint;
  * is determined by the intent passed in. This screen allows a user to view all of an
  * AbstractCategory's entries, edit them (by click), delete them (by long click), or create a new
  * one (by popup).
- * <br><br>
- * INTENTS: Expects to receive <i>either</i> {@link Constants#INTENT_EXTRA_VIEW_CATEGORIES} or
- * {@link Constants#INTENT_EXTRA_VIEW_SUB_CATEGORIES} to determine what screen to show.
  */
 @AndroidEntryPoint
 public class ViewAbstractCategoriesActivity extends AppCompatActivity {
+    private static final String TAG = ViewAbstractCategoriesActivity.class.getSimpleName();
     // The following are abstract limits and do not represent any limits imposed by the database
     private static final int NAME_CHARACTER_LIMIT = 128;
     private static final int DESCRIPTION_CHARACTER_LIMIT = 512;
@@ -89,9 +89,35 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
     private ProgressBar progressBar;
     private RecyclerView recyclerView;
 
-    private enum ActivityMode {
+    public enum ActivityMode {
         MODE_CATEGORIES,
         MODE_SUB_CATEGORIES
+    }
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the ViewAbstractCategoriesActivity for either Categories or SubCategories.
+     *
+     * @param context   Context.
+     * @param mode      The ActivityMode to launch the activity in, either Category or Sub-Category.
+     */
+    public static void startActivity(@NonNull Context context, @NonNull ActivityMode mode) {
+        Intent intent = new Intent(context, ViewAbstractCategoriesActivity.class);
+        switch (mode) {
+            case MODE_CATEGORIES:
+                intent.putExtra(Constants.INTENT_EXTRA_VIEW_CATEGORIES, "");
+                break;
+            case MODE_SUB_CATEGORIES:
+                intent.putExtra(Constants.INTENT_EXTRA_VIEW_SUB_CATEGORIES, "");
+                break;
+            default:
+                // No idea how this would happen, but whatever
+                Log.e(TAG, "Invalid mode for start activity: " + mode);
+                throw new RuntimeException("Invalid mode for start activity: " + mode);
+        }
+        context.startActivity(intent);
     }
 
     // =============================================================================================
@@ -201,7 +227,7 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
             // "Save" button
             String name = nameEditText.getText().toString();
             String description = descriptionEditText.getText().toString();
-            if (0 == name.length()) {
+            if (name.isEmpty()) {
                 UiUtils.displayDismissibleSnackbar(dialogView,
                         "Name can not be empty");
                 return; // Do not dismiss
@@ -211,7 +237,7 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
                 return; // Do not dismiss
             }
 
-            if (0 == description.length()) {
+            if (description.isEmpty()) {
                 UiUtils.displayDismissibleSnackbar(dialogView,
                         "Description can not be empty");
                 return; // Do not dismiss
@@ -279,7 +305,7 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
             // "Save" button
             String name = nameEditText.getText().toString();
             String description = descriptionEditText.getText().toString();
-            if (0 == name.length()) {
+            if (name.isEmpty()) {
                 UiUtils.displayDismissibleSnackbar(dialogView,
                         "Name can not be empty");
                 return; // Do not dismiss
@@ -289,7 +315,7 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
                 return; // Do not dismiss
             }
 
-            if (0 == description.length()) {
+            if (description.isEmpty()) {
                 UiUtils.displayDismissibleSnackbar(dialogView,
                         "Description can not be empty");
                 return; // Do not dismiss

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewAbstractCategoriesActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewAbstractCategoriesActivity.java
@@ -151,9 +151,7 @@ public class ViewAbstractCategoriesActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewDrillsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewDrillsActivity.java
@@ -132,9 +132,7 @@ public class ViewDrillsActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewDrillsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/ViewDrillsActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -66,8 +67,6 @@ import dagger.hilt.android.AndroidEntryPoint;
  * <br><br>
  * This screen allows a user to view all Drills, edit them (by click), delete them (by long click),
  * or create a new one (by launching {@link CreateDrillActivity}).
- * <br><br>
- * INTENTS: None expected.
  */
 @AndroidEntryPoint
 public class ViewDrillsActivity extends AppCompatActivity {
@@ -81,6 +80,19 @@ public class ViewDrillsActivity extends AppCompatActivity {
     private Button resetFiltersButton;
     private Button categoryFilterButton;
     private Button subCategoryFilterButton;
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the ViewDrillsActivity.
+     *
+     * @param context   Context.
+     */
+    public static void startActivity(@NonNull Context context) {
+        Intent intent = new Intent(context, ViewDrillsActivity.class);
+        context.startActivity(intent);
+    }
 
     // =============================================================================================
     // Activity Methods
@@ -178,8 +190,7 @@ public class ViewDrillsActivity extends AppCompatActivity {
     }
 
     public void createDrill(View view) {
-        Intent intent = new Intent(this, CreateDrillActivity.class);
-        startActivity(intent);
+        CreateDrillActivity.startActivity(this);
     }
 
     // =============================================================================================

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
@@ -109,9 +109,7 @@ public class WebDrillOptionsActivity extends AppCompatActivity {
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (R.id.homeButton == item.getItemId()) {
-            Intent intent = new Intent(this, HomeActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            HomeActivity.startActivity(this);
             finish();
             return true;
         }

--- a/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
+++ b/app/src/main/java/com/damienwesterman/defensedrill/ui/activities/WebDrillOptionsActivity.java
@@ -26,6 +26,7 @@
 
 package com.damienwesterman.defensedrill.ui.activities;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -64,8 +65,6 @@ import dagger.hilt.android.AndroidEntryPoint;
 /**
  * Screen to allow user to select from network related actions such as logging in or out to the
  * server, downloading, and updating drills from the server.
- * <br><br>
- * INTENTS: None expected.
  */
 @AndroidEntryPoint
 public class WebDrillOptionsActivity extends AppCompatActivity {
@@ -78,6 +77,29 @@ public class WebDrillOptionsActivity extends AppCompatActivity {
     CheckPhoneInternetConnection internetConnection;
 
     private WebDrillApiViewModel viewModel;
+
+    // =============================================================================================
+    // Activity Creation Methods
+    // =============================================================================================
+    /**
+     * Start the WebDrillOptionsActivity.
+     *
+     * @param context   Context.
+     */
+    public static void startActivity(@NonNull Context context) {
+        Intent webDrillsIntent = new Intent(context, WebDrillOptionsActivity.class);
+        context.startActivity(webDrillsIntent);
+    }
+
+    /**
+     * Create an intent designed to launch the WebDrillOptionsActivity.
+     *
+     * @param context   Context.
+     * @return          Intent that can be used to launch WebDrillOptionsActivity.
+     */
+    public static Intent createIntentToStartActivity(@NonNull Context context) {
+        return new Intent(context, WebDrillOptionsActivity.class);
+    }
 
     // =============================================================================================
     // Activity Methods


### PR DESCRIPTION
In order to keep a more maintainable, streamlined, and readable codebase, we want each activity to hold the logic responsible for its own creation. This way other classes won't have to worry about what intents it expects. The class will handle it and exposed the required values via parameters in startActivty() methods.